### PR TITLE
修复了 F2 快捷键失效的 bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dist
 
 # Visual Studio Code
 .vscode/
+
+# WebStorm
+.idea/

--- a/shortcut.user.js
+++ b/shortcut.user.js
@@ -69,18 +69,25 @@
 		) {
 			// F2：重命名对话，适用于聊天和文档的对话页面
 			e.preventDefault();
-			document.querySelector('svg-icon[key="edit"]')?.click();
-			return;
-		}
-
-		if (key === "a" && withKeys.altOnly(e)) {
-			// Alt + A：切换到绘图模式
-			e.preventDefault();
-			document
-				.querySelectorAll(
-					'div[nztooltipplacement="right"][nz-tooltip]',
-				)[2]
-				.click();
+			
+			// 获取当前活动对话的容器元素
+			const activeChat = document.querySelector('.active-conversation-item'); // 使用表示当前活动对话的 class
+			if (activeChat) {
+				// 在当前活动对话容器内找到并点击“更多”按钮
+				const moreButton = activeChat.querySelector('svg-icon[key="btn-more"]');
+				if (moreButton) {
+					moreButton.click();
+					
+					// 延时等待菜单加载出来
+					setTimeout(() => {
+						// 在当前活动对话容器内找到并点击“编辑对话名称”按钮
+						const editButton = document.querySelector('svg-icon[key="edit"]');
+						if (editButton) {
+							editButton.click();
+						}
+					}, 100); // 根据需要调整延迟时间
+				}
+			}
 			return;
 		}
 

--- a/shortcut.user.js
+++ b/shortcut.user.js
@@ -71,19 +71,12 @@
 			e.preventDefault();
 
 			// 获取当前活动对话的容器元素
-			const activeChat = document.querySelector('.active-conversation-item');
-			if (activeChat) {
-				// 在当前活动对话容器内找到并点击“更多”按钮
-				const moreButton = activeChat.querySelector('svg-icon[key="btn-more"]');
-				if (moreButton) {
-					moreButton.click();
-
-					// 在当前活动对话容器内找到并点击“编辑对话名称”按钮
-					const editButton = document.querySelector('svg-icon[key="edit"]');
-					if (editButton) {
-						editButton.click();
-					}
-				}
+			const activeConversation = document.querySelector('.active-conversation-item');
+			if (activeConversation !== null) {
+				// 在当前活动对话容器内点击“更多”按钮
+				activeConversation.querySelector('svg-icon[key="btn-more"]')?.click();
+				// 在当前活动对话容器内点击“编辑对话名称”按钮
+				document.querySelector('svg-icon[key="edit"]')?.click();
 			}
 			return;
 		}
@@ -220,18 +213,6 @@
 			// Alt + G：如果可以重新生成回答，重新生成最新的一个回答
 			e.preventDefault();
 			document.querySelector('[key="regenerate"]')?.click();
-			return;
-		}
-
-		if (
-			key === "enter" &&
-			withKeys.none(e) &&
-			e.target !== null &&
-			e.target === document.querySelector(".title-input")
-		) {
-			// 在重命名对话时按 Enter：保存新的对话名称
-			e.preventDefault();
-			document.querySelector('[nztype="primary"]')?.click();
 		}
 	});
 })();

--- a/shortcut.user.js
+++ b/shortcut.user.js
@@ -69,7 +69,7 @@
 		) {
 			// F2：重命名对话，适用于聊天和文档的对话页面
 			e.preventDefault();
-			
+
 			// 获取当前活动对话的容器元素
 			const activeChat = document.querySelector('.active-conversation-item');
 			if (activeChat) {
@@ -77,19 +77,17 @@
 				const moreButton = activeChat.querySelector('svg-icon[key="btn-more"]');
 				if (moreButton) {
 					moreButton.click();
-					
-					// 延时等待菜单加载出来
-					setTimeout(() => {
-						// 在当前活动对话容器内找到并点击“编辑对话名称”按钮
-						const editButton = document.querySelector('svg-icon[key="edit"]');
-						if (editButton) {
-							editButton.click();
-						}
-					}, 100); // 根据需要调整延迟时间
+
+					// 在当前活动对话容器内找到并点击“编辑对话名称”按钮
+					const editButton = document.querySelector('svg-icon[key="edit"]');
+					if (editButton) {
+						editButton.click();
+					}
 				}
 			}
 			return;
 		}
+
 
 		if (key === "a" && withKeys.altOnly(e)) {
 			// Alt + A：切换到绘图模式

--- a/shortcut.user.js
+++ b/shortcut.user.js
@@ -71,7 +71,7 @@
 			e.preventDefault();
 			
 			// 获取当前活动对话的容器元素
-			const activeChat = document.querySelector('.active-conversation-item'); // 使用表示当前活动对话的 class
+			const activeChat = document.querySelector('.active-conversation-item');
 			if (activeChat) {
 				// 在当前活动对话容器内找到并点击“更多”按钮
 				const moreButton = activeChat.querySelector('svg-icon[key="btn-more"]');

--- a/shortcut.user.js
+++ b/shortcut.user.js
@@ -91,6 +91,17 @@
 			return;
 		}
 
+		if (key === "a" && withKeys.altOnly(e)) {
+			// Alt + A：切换到绘图模式
+			e.preventDefault();
+			document
+				.querySelectorAll(
+					'div[nztooltipplacement="right"][nz-tooltip]',
+				)[2]
+				.click();
+			return;
+		}
+
 		if (key === "c" && withKeys.altOnly(e)) {
 			// Alt + C：切换到聊天模式
 			e.preventDefault();


### PR DESCRIPTION
原本的快捷键失效的原因是因为原脚本通过触发 edit 键值来修改标题名，但新 UI 中将 edit 键值隐藏，只有在点击“更多”（key="btn-more"）后才会显现。

新触发逻辑是找到 active 的窗口下的 btn-more 并触发，在等待 100ms 后再触发 edit.